### PR TITLE
feat: 发起请求时透传用户环境cookie等信息

### DIFF
--- a/src/app-updator.ts
+++ b/src/app-updator.ts
@@ -232,6 +232,7 @@ export abstract class AppUpdator extends EventEmitter {
         progressHandle: (data: any) => {
           this.emit(EventType.UPDATE_DOWNLOAD_PROGRESS, { ...data, executeType });
         },
+        headers: this.options?.headers,
       } as IDownloadFileOptions);
       this.logger.info('downloadUpdateFile:Downloaded');
       this.setState(StateType.Downloaded);

--- a/src/common/types/index.d.ts
+++ b/src/common/types/index.d.ts
@@ -52,6 +52,7 @@ export interface IAppUpdatorOptions {
   autoDownload?: boolean;
   productName?: string;
   getWindowsHelperExeDir?: () => string;
+  headers?: Record<string, string>;
 }
 
 interface IProgressHandleArg {
@@ -65,6 +66,7 @@ export interface IDownloadFileOptions {
   signature: string;
   targetDir: string;
   progressHandle: (progress: IProgressHandleArg) => void;
+  headers?: Record<string, string>;
 }
 
 export interface IAvailableUpdate {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -12,7 +12,7 @@ import { createWriteStream } from '.';
  * @param progressHandle 下载状态回调
  * @return
  */
-export const downloadFile = async ({ logger, url, signature, targetDir, progressHandle }: IDownloadFileOptions) => {
+export const downloadFile = async ({ logger, url, signature, targetDir, progressHandle, headers }: IDownloadFileOptions) => {
   logger.info('downloadFile#downloadFile (start)');
   const writeStream = createWriteStream(targetDir);
   let currentLength = 0;
@@ -26,6 +26,7 @@ export const downloadFile = async ({ logger, url, signature, targetDir, progress
         streaming: true,
         followRedirect: true,
         timeout: 10 * 60 * 1000,
+        headers,
       })
       .then((res: any) => {
         const totalLength = res.headers['content-length'];

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -92,7 +92,7 @@ export const existFile = async (path: string): Promise<boolean> => {
 };
 
 export const requestUpdateInfo = async (options: IAppUpdatorOptions): Promise<IUpdateInfo> => {
-  const { url } = options;
+  const { url, headers } = options;
   if (!url) {
     throw new Error('request url can\'t be empty');
   }
@@ -102,6 +102,7 @@ export const requestUpdateInfo = async (options: IAppUpdatorOptions): Promise<IU
     res = await urllib.request(url, {
       dataType: 'json',
       timeout: 10 * 1000,
+      headers,
     });
   } catch (e) {
     throw e;

--- a/test/utils/index.test.ts
+++ b/test/utils/index.test.ts
@@ -4,9 +4,11 @@ let mockRequire = require('mock-require');
 
 function generateMockUrllib() {
   let response = [] as any;
+  let lastRequestOptions = null as any;
 
   mockRequire('urllib', {
-    request: () => {
+    request: (_url: string, options: any) => {
+      lastRequestOptions = options;
       return response;
     },
   });
@@ -15,6 +17,7 @@ function generateMockUrllib() {
     setReturn: (array: any) => {
       response = array;
     },
+    getLastRequestOptions: () => lastRequestOptions,
   };
 }
 const mockUrllib = generateMockUrllib();
@@ -92,6 +95,40 @@ describe('test/utils/index.test.ts', () => {
       });
       const result = await requestUpdateInfo(updator);
       assert.equal(result.version, '7.2.2');
+    });
+
+    it('应将 headers 透传给 urllib.request', async () => {
+      const headers = { Cookie: 'session=abc123; token=xyz' };
+      const updator = {
+        url: 'https://github.com',
+        headers,
+      };
+      mockUrllib.setReturn({
+        status: 200,
+        data: {
+          isUpdate: true,
+          version: '1.0.0',
+        },
+      });
+      await requestUpdateInfo(updator);
+      const requestOptions = mockUrllib.getLastRequestOptions();
+      assert.deepEqual(requestOptions.headers, headers);
+    });
+
+    it('未传 headers 时不影响请求', async () => {
+      const updator = {
+        url: 'https://github.com',
+      };
+      mockUrllib.setReturn({
+        status: 200,
+        data: {
+          isUpdate: true,
+          version: '1.0.0',
+        },
+      });
+      await requestUpdateInfo(updator);
+      const requestOptions = mockUrllib.getLastRequestOptions();
+      assert.equal(requestOptions.headers, undefined);
     });
   });
 });


### PR DESCRIPTION
发起请求时，允许调用方传递额外的headers信息控制行为，例如传递cookie以允许拉取受保护的资源